### PR TITLE
新規ユーザー登録ページ　登録機能実装

### DIFF
--- a/app/assets/stylesheets/_user_registration.scss
+++ b/app/assets/stylesheets/_user_registration.scss
@@ -3,6 +3,11 @@
   position: relative;
   font-size: 14px;
   color: rgb(51, 51, 51);
+  .devise__error-messages{
+    display: flex;
+    color: red;
+    margin-top: 5px;
+  }
   .header {
     height: 128px;
     text-align: center;
@@ -37,6 +42,9 @@
         .side {
           display:inline-block;
         }
+        .top_space{
+          margin-top: 28px;
+        }
         &--title {
           font-weight: 600;
         }
@@ -60,7 +68,7 @@
           border-radius: 4px;
           border: 1px solid #ccc;
           background: white;
-          margin: 8px 0 28px 0;
+          margin: 8px 0 0 0;
         }
         input.input-default-half {
           width: calc(100% - 44px);

--- a/app/assets/stylesheets/_user_registration.scss
+++ b/app/assets/stylesheets/_user_registration.scss
@@ -53,9 +53,9 @@
         &--input {
           display: flex;
         }
-        input {
+        input.input-form {
           height: 30px;
-          width:100%;
+          width: calc(100% - 32px);
           padding: 10px 16px 8px;
           border-radius: 4px;
           border: 1px solid #ccc;
@@ -63,6 +63,7 @@
           margin: 8px 0 28px 0;
         }
         input.input-default-half {
+          width: calc(100% - 44px);
           margin-right: 10px;
         }
         &--identification {
@@ -74,22 +75,26 @@
         }
         &--select {
           display: flex;
-          &-year {
-            margin-right: 10px;
+          position: relative;
+          line-height:  48px;
+          #user_birth_day_1i {
+            width: 97px;
           }
-          &-month {
-            margin-right: 10px;
+          #user_birth_day_2i {
+            width: 84px;
           }
-          &-day {
-            margin-right: 10px;
+          #user_birth_day_3i {
+            width: 84px;
           }
-        select {
-          height: 48px;
-          width: 70%;
-          border: 1px solid #ccc;
-          background: 0;
-          font-size: 16px;
-        }
+          select {
+            height: 48px;
+            border: 1px solid #ccc;
+            background: 0;
+            font-size: 16px;
+          }
+          p{
+            line-height:  48px;
+          }
         }
         &--attentions {
           color: lightslategrey;
@@ -108,11 +113,20 @@
           width:100%;
           height: 50px;
           margin: 0 0 0 8px;
+          cursor: pointer;
         }
         &--attentions-guide {
           text-align: right;
           color: lightskyblue;
           margin: 24px 00;
+        }
+        .field_with_errors{
+          width: 100%;
+          height: 100%;
+          input, select{
+          border-color: red;
+          background-color:white;
+          }
         }
       }
     }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,6 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable, password_length: 7...128
   validates :nickname, :email, :password, :last_name, :first_name, :last_name, :first_name_kana, :last_name_kana, :birth_day, presence: true
   validates :nickname, :email, uniqueness: true
-  validates :first_name, :last_name, format: { with: /\A(?:\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々])+\z/, message: '全角で入力して下さい。'}
-  validates :first_name_kana, :last_name_kana, format: { with: /\A[ァ-ヶー－]+\z/, message: '全角カタカナで入力して下さい。'}
+  validates :first_name, :last_name, format: { with: /\A(?:\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々])+\z/, message: 'を全角で入力して下さい。'}
+  validates :first_name_kana, :last_name_kana, format: { with: /\A[ァ-ヶー－]+\z/, message: 'を全角カタカナで入力して下さい。'}
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -8,82 +8,66 @@
     .head-registration
       会員情報入力
     .inner-registration
-      .inner-registration__contents
-        .inner-registration__contents--title.side
-          ニックネーム
-        .inner-registration__contents--require.side
-          必須
-        .inner-registration__contents--input
-          %input{type:"text", placeholder:"例）メルカリ太郎",name:"content"}
-        .inner-registration__contents--title.side
-          メールアドレス
-        .inner-registration__contents--require.side
-          必須
-        .inner-registration__contents--input
-          %input{type:"text", placeholder:"PC・携帯どちらでも可",name:"content"}
-        .inner-registration__contents--title.side
-          パスワード
-        .inner-registration__contents--require.side
-          必須
-        .inner-registration__contents--input
-          %input{type:"text", placeholder:"7文字以上",name:"content"}
-        .inner-registration__contents--title.side
-          パスワード（確認）
-        .inner-registration__contents--require.side
-          必須
-        .inner-registration__contents--input
-          %input{type:"text", placeholder:"7文字以上",name:"content"}
-        .inner-registration__contents--identification
-          本人確認
-        .inner-registration__contents--text
-          安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
-        .inner-registration__contents--title.side
-          お名前（全角）
-        .inner-registration__contents--require.side
-          必須
-        .inner-registration__contents--input
-          %input{type:"text", placeholder:"例）山田",name:"content", class: "input-default-half"}
-          %input{type:"text", placeholder:"例）彩",name:"content", class: "input-default-half"}
-        .inner-registration__contents--title.side
-          お名前カナ（全角）
-        .inner-registration__contents--require.side
-          必須
-        .inner-registration__contents--input
-          %input{type:"text", placeholder:"例）ヤマダ",name:"content", class: "input-default-half"}
-          %input{type:"text", placeholder:"例）アヤ",name:"content", class: "input-default-half"}
-        .inner-registration__contents--title.side
-          生年月日
-        .inner-registration__contents--require.side
-          必須
-        .inner-registration__contents--select
-          .inner-registration__contents--select-year
-            %form{action: "#", method: "GET"}
-            %select{name: "content"}
-              %option{value: ""} ---
-              %option{value: "2019"} 2019
-            年
-          .inner-registration__contents--select-month
-            %form{action: "#", method: "GET"}
-            %select{name: "content"}
-              %option{value: ""} ---
-              %option{value: "1"} 1
-            月
-          .inner-registration__contents--select-day
-            %form{action: "#", method: "GET"}
-            %select{name: "content"}
-              %option{value: ""} ---
-              %option{value: "1"} 1
-            日
-        .inner-registration__contents--attentions
-          ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
-        .hinner-registration__contents--authentication
-        = image_tag '/images/reCAPTCHA.png',height:"80px",width:"320px;"
-        .inner-registration__contents--agreement
-          「次へ進む」のボタンを押すことにより、利用規約に同意したものとみなします
-        .inner-registration__contents--next-btn
-          次へ進む
-        .inner-registration__contents--attentions-guide
-          本人情報の登録について
+      = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+        .inner-registration__contents
+          .inner-registration__contents--title.side
+            ニックネーム
+          .inner-registration__contents--require.side
+            必須
+          .inner-registration__contents--input
+            = f.text_field :nickname, placeholder:"例）メルカリ太郎", class: "input-form"
+          .inner-registration__contents--title.side
+            メールアドレス
+          .inner-registration__contents--require.side
+            必須
+          .inner-registration__contents--input
+            = f.email_field :email, autocomplete: "email", placeholder:"PC・携帯どちらでも可", class: "input-form"
+          .inner-registration__contents--title.side
+            パスワード
+          .inner-registration__contents--require.side
+            必須
+          .inner-registration__contents--input
+            = f.password_field :password, autocomplete: "new-password", placeholder:"7文字以上", class: "input-form"
+          .inner-registration__contents--title.side
+            パスワード（確認）
+          .inner-registration__contents--require.side
+            必須
+          .inner-registration__contents--input
+            = f.password_field :password_confirmation, autocomplete: "new-password", placeholder:"7文字以上", class: "input-form"
+          .inner-registration__contents--identification
+            本人確認
+          .inner-registration__contents--text
+            安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
+          .inner-registration__contents--title.side
+            お名前（全角）
+          .inner-registration__contents--require.side
+            必須
+          .inner-registration__contents--input
+            = f.text_field :last_name, placeholder:"例）山田", class: "input-default-half input-form"
+            = f.text_field :first_name, placeholder:"例）彩", class: "input-default-half input-form"
+          .inner-registration__contents--title.side
+            お名前カナ（全角）
+          .inner-registration__contents--require.side
+            必須
+          .inner-registration__contents--input
+            = f.text_field :last_name_kana, placeholder:"例）ヤマダ", class: "input-default-half input-form"
+            = f.text_field :first_name_kana, placeholder:"例）アヤ", class: "input-default-half input-form"
+          .inner-registration__contents--title.side
+            生年月日
+          .inner-registration__contents--require.side
+            必須
+          .inner-registration__contents--select
+            = raw sprintf(f.date_select(:birth_day, use_month_numbers: true, start_year: 1900, end_year: (Time.now.year), prompt: "--", date_separator: '%s'),"年 \n", '月 ')
+            %p 日
+          .inner-registration__contents--attentions
+            ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
+          .hinner-registration__contents--authentication
+          = image_tag '/images/reCAPTCHA.png',height:"80px",width:"320px;"
+          .inner-registration__contents--agreement
+            「次へ進む」のボタンを押すことにより、利用規約に同意したものとみなします
+          = f.submit "次へ進む", class: "inner-registration__contents--next-btn"
+          .inner-registration__contents--attentions-guide
+            本人情報の登録について
   .footer-user
     .footer-user__guide
       .footer-user__guide--privacy

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -16,49 +16,58 @@
             必須
           .inner-registration__contents--input
             = f.text_field :nickname, placeholder:"例）メルカリ太郎", class: "input-form"
-          .inner-registration__contents--title.side
+          = render partial: "devise/shared/custom_error_message", locals: { content: :nickname, f: f}
+          .inner-registration__contents--title.side.top_space
             メールアドレス
-          .inner-registration__contents--require.side
+          .inner-registration__contents--require.side.top_space
             必須
           .inner-registration__contents--input
             = f.email_field :email, autocomplete: "email", placeholder:"PC・携帯どちらでも可", class: "input-form"
-          .inner-registration__contents--title.side
+          = render partial: "devise/shared/custom_error_message", locals: { content: :email, f: f}
+          .inner-registration__contents--title.side.top_space
             パスワード
-          .inner-registration__contents--require.side
+          .inner-registration__contents--require.side.top_space
             必須
           .inner-registration__contents--input
             = f.password_field :password, autocomplete: "new-password", placeholder:"7文字以上", class: "input-form"
-          .inner-registration__contents--title.side
+          = render partial: "devise/shared/custom_error_message", locals: { content: :password, f: f}
+          .inner-registration__contents--title.side.top_space
             パスワード（確認）
-          .inner-registration__contents--require.side
+          .inner-registration__contents--require.side.top_space
             必須
           .inner-registration__contents--input
             = f.password_field :password_confirmation, autocomplete: "new-password", placeholder:"7文字以上", class: "input-form"
+          = render partial: "devise/shared/custom_error_message", locals: { content: :password_confirmation, f: f}
           .inner-registration__contents--identification
             本人確認
           .inner-registration__contents--text
             安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
-          .inner-registration__contents--title.side
+          .inner-registration__contents--title.side.top_space
             お名前（全角）
-          .inner-registration__contents--require.side
+          .inner-registration__contents--require.side.top_space
             必須
           .inner-registration__contents--input
             = f.text_field :last_name, placeholder:"例）山田", class: "input-default-half input-form"
             = f.text_field :first_name, placeholder:"例）彩", class: "input-default-half input-form"
-          .inner-registration__contents--title.side
+          = render partial: "devise/shared/custom_error_message", locals: { content: :last_name, f: f}
+          = render partial: "devise/shared/custom_error_message", locals: { content: :first_name, f: f}
+          .inner-registration__contents--title.side.top_space
             お名前カナ（全角）
-          .inner-registration__contents--require.side
+          .inner-registration__contents--require.side.top_space
             必須
           .inner-registration__contents--input
             = f.text_field :last_name_kana, placeholder:"例）ヤマダ", class: "input-default-half input-form"
             = f.text_field :first_name_kana, placeholder:"例）アヤ", class: "input-default-half input-form"
-          .inner-registration__contents--title.side
+          = render partial: "devise/shared/custom_error_message", locals: { content: :last_name_kana, f: f}
+          = render partial: "devise/shared/custom_error_message", locals: { content: :first_name_kana, f: f}
+          .inner-registration__contents--title.side.top_space
             生年月日
-          .inner-registration__contents--require.side
+          .inner-registration__contents--require.side.top_space
             必須
           .inner-registration__contents--select
             = raw sprintf(f.date_select(:birth_day, use_month_numbers: true, start_year: 1900, end_year: (Time.now.year), prompt: "--", date_separator: '%s'),"年 \n", '月 ')
             %p 日
+          = render partial: "devise/shared/custom_error_message", locals: { content: :birth_day, f: f}
           .inner-registration__contents--attentions
             ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
           .hinner-registration__contents--authentication

--- a/app/views/devise/shared/_custom_error_message.html.haml
+++ b/app/views/devise/shared/_custom_error_message.html.haml
@@ -1,0 +1,7 @@
+- if resource.errors.messages[content].any?
+  - resource.errors.messages[content].uniq.each do |message|
+    .devise__error-messages
+      .devise__error-message
+        = f.label content
+      .devise__error-message
+        = message

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,6 @@ module FreemarketSample0810B
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,84 @@
+ja:
+  devise:
+    confirmations:
+      confirmed: 'アカウントを登録しました。'
+      send_instructions: 'アカウントの有効化について数分以内にメールでご連絡します。'
+      send_paranoid_instructions: "あなたのメールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。"
+    failure:
+      already_authenticated: 'すでにログインしています。'
+      inactive: 'アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。'
+      invalid: "%{authentication_keys} もしくはパスワードが不正です。"
+      locked: 'あなたのアカウントは凍結されています。'
+      last_attempt: 'あなたのアカウントが凍結される前に、複数回の操作がおこなわれています。'
+      not_found_in_database: "%{authentication_keys} もしくはパスワードが不正です。"
+      timeout: 'セッションがタイムアウトしました。もう一度ログインしてください。'
+      unauthenticated: 'アカウント登録もしくはログインしてください。'
+      unconfirmed: 'メールアドレスの本人確認が必要です。'
+    mailer:
+      confirmation_instructions:
+        subject: 'アカウントの有効化について'
+      reset_password_instructions:
+        subject: 'パスワードの再設定について'
+      unlock_instructions:
+        subject: 'アカウントの凍結解除について'
+      password_change:
+        subject: 'パスワードの変更について'
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      no_token: "このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。"
+      send_instructions: 'パスワードの再設定について数分以内にメールでご連絡いたします。'
+      send_paranoid_instructions: "あなたのメールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。"
+      updated: 'パスワードが正しく変更されました。'
+      updated_not_active: 'パスワードが正しく変更されました。'
+    registrations:
+      destroyed: 'アカウントを削除しました。またのご利用をお待ちしております。'
+      signed_up: 'アカウント登録が完了しました。'
+      signed_up_but_inactive: 'ログインするためには、アカウントを有効化してください。'
+      signed_up_but_locked: 'アカウントが凍結されているためログインできません。'
+      signed_up_but_unconfirmed: '本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。'
+      update_needs_confirmation: 'アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。'
+      updated: 'アカウント情報を変更しました。'
+    sessions:
+      signed_in: 'ログインしました。'
+      signed_out: 'ログアウトしました。'
+      already_signed_out: '既にログアウト済みです。'
+    unlocks:
+      send_instructions: 'アカウントの凍結解除方法を数分以内にメールでご連絡します。'
+      send_paranoid_instructions: 'アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。'
+      unlocked: 'アカウントを凍結解除しました。'
+  errors:
+    messages:
+      already_confirmed: 'は既に登録済みです。ログインしてください。'
+      confirmation_period_expired: "の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。"
+      expired: 'の有効期限が切れました。新しくリクエストしてください。'
+      not_found: 'は見つかりませんでした。'
+      not_locked: 'は凍結されていません。'
+      not_saved:
+        one: "エラーが発生したため %{resource} は保存されませんでした:"
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした:"
+      taken: "は既に使用されています。"
+      blank: "が入力されていません。"
+      too_short: "は%{count}文字以上に設定して下さい。"
+      too_long: "は%{count}文字以下に設定して下さい。"
+      invalid: "は有効でありません。"
+      confirmation: "が内容とあっていません。"
+  date:
+    month_names: [~, 1月, 2月, 3月, 4月, 5月, 6月, 7月, 8月, 9月, 10月, 11月, 12月]
+    order:
+      - :year
+      - :month
+      - :day
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        password: パスワード
+        password_confirmation: パスワード(確認)
+        email: メールアドレス
+        last_name: 姓
+        last_name_kana: 姓カナ
+        first_name: 名
+        first_name_kana: 名カナ
+        birth_day: 生年月日

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -63,7 +63,7 @@ ja:
       too_short: "は%{count}文字以上に設定して下さい。"
       too_long: "は%{count}文字以下に設定して下さい。"
       invalid: "は有効でありません。"
-      confirmation: "が内容とあっていません。"
+      confirmation: "が異なります。"
   date:
     month_names: [~, 1月, 2月, 3月, 4月, 5月, 6月, 7月, 8月, 9月, 10月, 11月, 12月]
     order:


### PR DESCRIPTION
# WHAT
新規ユーザー登録ページの実装。
別々に作成された機能とフロントの統合。
バリデーションエラーの追加表示。日本語化。

# WHY
deviseのデフォルトに追加したユーザ項目に対応する。(nickname,first_name等)
デフォルトから見栄え良くして、使用感を向上させる。
