### PR TITLE
テストコードの作成　単体モデル(addressとsns_credential)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ group :development, :test do
   gem 'byebug', platform: :mri
   gem 'rspec-rails'
   gem 'factory_bot_rails'
+  gem 'rails-controller-testing'
+  gem 'faker'
+  gem 'gimei'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     factory_bot_rails (5.0.2)
       factory_bot (~> 5.0.2)
       railties (>= 4.2.0)
+    faker (2.3.0)
+      i18n (~> 1.6.0)
     faraday (0.16.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
@@ -122,6 +124,8 @@ GEM
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
     formatador (0.2.5)
+    gimei (0.3.0)
+      romaji
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.1.2)
@@ -227,6 +231,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.0.7.2)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.4)
+      actionpack (>= 5.0.1.x)
+      actionview (>= 5.0.1.x)
+      activesupport (>= 5.0.1.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -249,6 +257,8 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    romaji (0.2.4)
+      rake (>= 0.8.0)
     rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.4)
@@ -338,8 +348,10 @@ DEPENDENCIES
   devise
   erb2haml
   factory_bot_rails
+  faker
   fog-aws
   font-awesome-rails
+  gimei
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails
@@ -353,6 +365,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)
+  rails-controller-testing
   rails-i18n
   rspec-rails
   sass-rails (~> 5.0)

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,8 +1,8 @@
 class Address < ApplicationRecord
   validates :postal_code, format: { with: /\A[0-9]{7}\z/, message: 'のフォーマットが不適切です'}, on: :create
   validates :postal_code, format: { with: /\A[0-9]{7}\z/, message: 'のフォーマットが不適切です'}, allow_blank: true ,on: :update
-  validates :postal_code, :city, :street, presence: true, on: :create
-  validates :prefecture, exclusion: { in: %w(---) ,  message: 'を選択してください'}, on: :create
+  validates :prefecture, exclusion: { in: %w(---) ,  message: 'を選択してください'}, presence: true, on: :create
+  validates :postal_code, :prefecture, :city, :street, presence: true, on: :create
   belongs_to :user, inverse_of: :address
 
   enum prefecture:{

--- a/app/models/sns_credential.rb
+++ b/app/models/sns_credential.rb
@@ -1,3 +1,5 @@
 class SnsCredential < ApplicationRecord
   belongs_to :user
+  validates :provider, :uid, presence: true
+  validates_uniqueness_of :uid, :scope => :provider 
 end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+
+  factory :address do
+    postal_code                { Faker::Number.number(digits: 7)}
+    prefecture                 { Gimei.prefecture.kanji }
+    city                       { Gimei.city.kanji }
+    street                     { Gimei.town.kanji }
+    building_name              { Gimei.last.kanji }
+    phone                      { Faker::Number.number(digits: 11)}
+    user
+  end
+  
+end

--- a/spec/factories/sns_credentials.rb
+++ b/spec/factories/sns_credentials.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+
+  factory :google, class: SnsCredential do
+    provider            {Faker::Omniauth.google[:provider]}
+    uid                 {Faker::Omniauth.google[:uid]}
+    user
+  end
+
+  factory :facebook, class: SnsCredential  do
+    provider            {Faker::Omniauth.facebook[:provider]}
+    uid                 {Faker::Omniauth.facebook[:uid]}
+    user
+  end
+
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,14 +1,15 @@
 FactoryBot.define do
 
   factory :user do
-    nickname              {"abe"}
-    email                 {"kkk@gmail.com"}
-    password              {"00000000"}
-    password_confirmation {"00000000"}
-    last_name             {"田中"}
-    first_name            {"てすと"}
-    last_name_kana        {"カキクケコ"}
-    first_name_kana       {"アイウエオ"}
+    nickname              {Faker::Name.last_name}
+    email                 {Faker::Internet.free_email}
+    password = Faker::Internet.password(min_length: 8)
+    password              {password}
+    password_confirmation {password}
+    last_name             {Gimei.last.kanji }
+    first_name            {Gimei.first.hiragana}
+    last_name_kana        {Gimei.last.katakana}
+    first_name_kana       {Gimei.first.katakana}
     birth_day             {"20190415"}
   end
 

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+describe Address do
+  describe '#create' do
+    it "is valid with postal_code, city, street, prefecture" do
+      address = build(:address, building_name: "", phone: "")
+      expect(address).to be_valid
+    end
+    
+    it "is invalid without a postal_code"  do
+      address = build(:address, postal_code: "")
+      address.valid?
+      expect(address.errors[:postal_code]).to include("が入力されていません。")
+    end
+
+    it "is invalid without a prefecture"  do
+      address = build(:address, prefecture: "")
+      address.valid?
+      expect(address.errors[:prefecture]).to include("が入力されていません。")
+    end
+
+    it "is invalid without a city"  do
+      address = build(:address, city: "")
+      address.valid?
+      expect(address.errors[:city]).to include("が入力されていません。")
+    end
+
+    it "is invalid without a street"  do
+      address = build(:address, street: "")
+      address.valid?
+      expect(address.errors[:street]).to include("が入力されていません。")
+    end
+
+    it "is invalid with a postal_code thas has less than 6 characters " do
+      address = build(:address, postal_code: Faker::Number.number(digits: 6))
+      address.valid?
+      expect(address.errors[:postal_code]).to include("のフォーマットが不適切です")
+    end
+
+    it "is invalid with a postal_code thas has more than 8 characters " do
+      address = build(:address, postal_code: Faker::Number.number(digits: 8))
+      address.valid?
+      expect(address.errors[:postal_code]).to include("のフォーマットが不適切です")
+    end
+
+    it "is invalid with a postal_code thas has other than numbers " do
+      address = build(:address, postal_code: "abcdefg")
+      address.valid?
+      expect(address.errors[:postal_code]).to include("のフォーマットが不適切です")
+    end
+  end
+  describe '#update' do
+    it "is valid with empty other than prefecuture is default" do
+      address = build(:address)
+      address.save
+      address.update(postal_code: "", prefecture: "---", city: "", street: "", building_name: "", phone: "")
+      expect(address).to be_valid
+    end
+    
+    it "is invalid with a postal_code thas has less than 6 characters " do
+      address = build(:address)
+      address.update(postal_code: Faker::Number.number(digits: 6))
+      expect(address.errors[:postal_code]).to include("のフォーマットが不適切です")
+    end
+
+    it "is invalid with a postal_code thas has more than 8 characters " do
+      address = build(:address)
+      address.update(postal_code: Faker::Number.number(digits: 8))
+      expect(address.errors[:postal_code]).to include("のフォーマットが不適切です")
+    end
+
+    it "is invalid with a postal_code thas has other than numbers " do
+      address = build(:address)
+      address.update(postal_code: "abcdefg")
+      expect(address.errors[:postal_code]).to include("のフォーマットが不適切です")
+    end
+  end
+end

--- a/spec/models/sns_credential_spec.rb
+++ b/spec/models/sns_credential_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+describe SnsCredential do
+  describe '#create' do
+    it "is valid with a provider, uid, user_id (google)" do
+      sns_credential = build(:google)
+      expect(sns_credential).to be_valid
+    end
+
+    it "is valid with a provider, uid, user_id (facebook)" do
+      sns_credential = build(:facebook)
+      expect(sns_credential).to be_valid
+    end
+
+    it "is invalid without a provider(google)"  do
+      sns_credential = build(:google, provider: "")
+      sns_credential.valid?
+      expect(sns_credential.errors[:provider]).to include("が入力されていません。")
+    end
+
+    it "is invalid without a provider(facebook)"  do
+      sns_credential = build(:facebook, provider: "")
+      sns_credential.valid?
+      expect(sns_credential.errors[:provider]).to include("が入力されていません。")
+    end
+
+    it "is invalid without a uid(google)"  do
+      sns_credential = build(:google, uid: "")
+      sns_credential.valid?
+      expect(sns_credential.errors[:uid]).to include("が入力されていません。")
+    end
+
+    it "is invalid without a uid(facebook)"  do
+      sns_credential = build(:facebook, uid: "")
+      sns_credential.valid?
+      expect(sns_credential.errors[:uid]).to include("が入力されていません。")
+    end
+
+    it "is invalid with a duplicate uid and provider (google)"  do
+      sns_credential = create(:google)
+      another_sns_credential = build(:google, uid: sns_credential.uid)
+      another_sns_credential.valid?
+      expect(another_sns_credential.errors[:uid]).to include("は既に使用されています。")
+    end
+
+    it "is invalid with a duplicate uid and provider (facebook)"  do
+      sns_credential = create(:facebook)
+      another_sns_credential = build(:facebook, uid: sns_credential.uid)
+      another_sns_credential.valid?
+      expect(another_sns_credential.errors[:uid]).to include("は既に使用されています。")
+    end
+
+    it "is valid if same uid but dirrent provider"  do
+      sns_credential = create(:google)
+      another_sns_credential = build(:facebook, uid: sns_credential.uid)
+      another_sns_credential.valid?
+      expect(another_sns_credential).to be_valid
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -89,25 +89,25 @@ describe User do
     it "is invalid other than double-byte characters is included in last_name"  do
       user = build(:user, last_name: "あいうえお愛ueお")
       user.valid?
-      expect(user.errors[:last_name]).to include("を全角で入力して下さい。")
+      expect(user.errors[:last_name]).to include("全角で入力して下さい。")
     end
 
     it "is invalid other than double-byte characters is included in first_name"  do
       user = build(:user, first_name: "かきくけこ牡蠣くけ5")
       user.valid?
-      expect(user.errors[:first_name]).to include("を全角で入力して下さい。")
+      expect(user.errors[:first_name]).to include("全角で入力して下さい。")
     end
 
     it "is invalid other than double-byte katakana characters is included in last_name_kana"  do
       user = build(:user, last_name_kana: "アイウエo愛ueお")
       user.valid?
-      expect(user.errors[:last_name_kana]).to include("を全角カタカナで入力して下さい。")
+      expect(user.errors[:last_name_kana]).to include("全角カタカナで入力して下さい。")
     end
 
     it "is invalid other than double-byte katakana characters is included in first_name_kana"  do
       user = build(:user, first_name_kana: "アイウエオ牡蠣くけ5")
       user.valid?
-      expect(user.errors[:first_name_kana]).to include("を全角カタカナで入力して下さい。")
+      expect(user.errors[:first_name_kana]).to include("全角カタカナで入力して下さい。")
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,5 +59,7 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
-  
+  Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include ControllerMacros, type: :controller
 end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,0 +1,6 @@
+module ControllerMacros
+  def login(user)
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+    sign_in user
+  end
+end


### PR DESCRIPTION
# WHAT
addressモデルとsns_credentialモデルの単体テストコード作成。
# WHY
不適切なデータの混在を防止するため。
