### PR TITLE
フロント：サインインページの作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,6 +21,7 @@
 @import "item_register";
 @import "item_buy";
 @import "signup/step1_top";
+@import "signup/step1_login";
 @import "signup/step2_mail";
 @import "signup/step3_tel";
 @import "signup/step4_address";

--- a/app/assets/stylesheets/signup/step1_login.scss
+++ b/app/assets/stylesheets/signup/step1_login.scss
@@ -1,0 +1,132 @@
+.account-page__login {
+  background-color:rgb(245, 245, 245);
+  position: relative;
+  font-size: 14px;
+  color: rgb(51, 51, 51);
+  .header {
+    height: 128px;
+    text-align: center;
+    &__logo{
+      margin: 20px 0px 20px 0px;
+      display: inline-block;
+    }
+  }
+  .registration__container {
+    width: 456px;
+    margin: 0 auto;
+    background-color: white;
+  }
+  .registration__title {
+    font-size: 14px;
+    line-height: 14px;
+    padding: 32px;
+    text-align: center;
+  }
+  .registration-form {
+    padding: 40px 32px 20px;
+    border-top: 1px solid #f5f5f5;
+    &__content {
+      width: 100%;
+      margin: 0 auto;
+    }
+  }
+  .btn {
+    position: relative;
+    display: block;
+    width: 100%;
+    line-height: 48px;
+    font-size: 14px;
+    border: 1px solid transparent;
+    transition: all ease-out .3s;
+    cursor: pointer;
+    text-align: center;
+    text-decoration: none; 
+    &--login {
+      margin: 40px 0;
+      color: #fff;
+      background-color: #ea352d;
+    }
+    &--facebook {
+      margin: 16px 0 0;
+      background: #385185;
+      color: #fff;
+    }
+    &--google {
+      margin: 16px 0 32px;
+      background: #fff;
+      border: #979797 solid 1px;
+      color: #333;
+    }
+    &--signup {
+      margin: 16px 0 0;
+      background: dodgerblue;
+      color: #fff;
+      height: 40px;
+      line-height: 40px;
+      font-weight: normal;
+    }
+  }
+  .forget-password{
+    color: dodgerblue;
+    text-decoration: none;
+  }
+  .envelop-icon {
+    position: absolute;
+    top: 25%;
+    left: 16px;
+    font-size: 22px;
+  }
+  .facebook-icon {
+    position: absolute;
+    top: 25%;
+    left: 16px;
+    font-size: 28px;
+  }
+  .google-icon {
+    position: absolute;
+    top: 25%;
+    left: 16px;
+    font-size: 26px;
+  }
+  .password-login, .email-login{
+    height: 30px;
+    width: calc(100% - 32px);
+    padding: 10px 16px 8px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    background: white;
+    margin: 16px 0 0 0;
+    &:focus{
+      border: 1px solid dodgerblue;
+      outline: 0;
+    }
+  }
+  .footer-user {
+    width: 456px;
+    height: 220px;
+    margin: 0 auto;
+    text-align: center;
+    &__guide {
+      list-style: none;
+      font-size: 12px;
+      display:flex;
+      justify-content: center;
+      margin-top: 30px;
+      &--privacy {
+        padding-right: 15px;
+      }
+      &--terms {
+        padding-right: 15px;
+      }
+      &--notification {
+        padding-right: 15px;
+      }
+    }
+    &__logo {
+    margin: 40px auto 0;
+    }
+    &__copyright {
+      font-size: 11px;
+    }
+  }
+}

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,17 +1,30 @@
-%h2 Log in
-= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  .field
-    = f.label :password
-    %br/
-    = f.password_field :password, autocomplete: "current-password"
-  - if devise_mapping.rememberable?
-    .field
-      = f.check_box :remember_me
-      = f.label :remember_me
-  .actions
-    = f.submit "Log in"
-= render "devise/shared/links"
+.account-page__login
+  %header.header
+    %h1.header__logo
+      =link_to root_path do
+        = image_tag '/images/logo-main.png', height:"52px", width:"190px;", alt: "mercari", class: "header__logo"
+  %main.registration
+    %section.registration__container
+      %p.registration__title 
+        アカウントをお持ちでない方はこちら
+        =link_to users_signup_index_path, class: "btn btn--signup" do
+          新規会員登録
+      .registration-form
+        .registration-form__content
+          =link_to user_facebook_omniauth_authorize_path, method: :post, class: "btn btn--facebook" do
+            %i.fa.fa-facebook-square.facebook-icon
+            Facebookでログイン
+          =link_to user_google_oauth2_omniauth_authorize_path, method: :post, class: "btn btn--google" do
+            %i.fa.fa-google.google-icon
+            Googleでログイン
+          = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+            .field
+              = f.email_field :email, autofocus: true, autocomplete: "email", class: "email-login", placeholder: "メールアドレス"
+            .field
+              = f.password_field :password, autocomplete: "current-password", class: "password-login", placeholder: "パスワード"
+            .actions
+              = f.submit "ログイン", class: "btn btn--login"
+          - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
+            = link_to new_password_path(resource_name) , class: "forget-password"do
+              パスワードをお忘れの方
+  = render 'devise/registrations/footer'


### PR DESCRIPTION
#WHAT
サインインページの作成。
#WHY
現在deviseで作成されたのデフォルト表示のため、見栄えの向上。
サインインの選択を可能にする。

*ログイン失敗の際の挙動は未調整。