### PR TITLE
【WIP】

### DIFF
--- a/app/assets/javascripts/selectbox.js
+++ b/app/assets/javascripts/selectbox.js
@@ -172,7 +172,7 @@ $(function () {
     .done(function(size){
       $("#hidden_size").empty();
       size_clothes();
-      if (size.id == "4"|| size.id == "5" || size.id == "6" || size.id == "7" || size.id == "8" || size.id == "9" || size.id == "10" || size.id == "11" || size.id == "13"){
+      if (size.id == "4"|| size.id == "5" || size.id == "6" || size.id == "7" || size.id == "8" || size.id == "9" || size.id == "10" || size.id == "11" || size.id == "12" || size.id == "13"){
         $("#hidden_size").empty();
       }
       if(size.id_two == "19" || size.id_two == "36" || size.id_two == "53"){

--- a/app/assets/javascripts/sum.js
+++ b/app/assets/javascripts/sum.js
@@ -2,10 +2,10 @@ $(function () {
   $(".side_cost").keyup(function() { 
     var val = $('#sum').val();
     if(val >= 300){
-    var fee = val*0.1
+    var fee = Math.floor(val*0.1)
     var benefit = val-fee
-    $(".side_fee").text(fee);
-    $(".side_benefit").text(benefit);
+    $(".side_fee").text("¥ " + fee);
+    $(".side_benefit").text("¥ " + benefit);
     }
     if(val<300){
       $(".side_fee").text("-");

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,7 +12,6 @@ class Item < ApplicationRecord
   def image_save
     errors.add(:image, "") if images.empty?
   end
-
   # has_many :comments
   # has_many :likes
   # has_one :status

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,12 +5,17 @@ class Item < ApplicationRecord
   accepts_nested_attributes_for :images
   has_one :buyer
 
-  validates :name, :detail, :price, :size, :category_id,:condition, :shipping_fee, :shipping_method, :ship_out_area, :ship_out_date ,presence: true
+  validates :name, :detail, :price, :category_id,:condition, :shipping_fee, :shipping_method, :ship_out_area, :ship_out_date ,presence: true
   validates :name, length: {maximum: 40}
+  validates :size, presence: true, if: :size_exist?
   validate  :image_save,on:[:new, :create]
 
   def image_save
     errors.add(:image, "") if images.empty?
+  end
+
+  def size_exist?
+    category_id.to_i < 577
   end
   # has_many :comments
   # has_many :likes

--- a/app/views/items/_item_error.html.haml
+++ b/app/views/items/_item_error.html.haml
@@ -13,5 +13,6 @@
             画像を選択してください
           -elsif content == :price
             300以上9999999以下で入力してください
+          -elsif content == :size && params[:category_id].nil?
           -else
             選択してください

--- a/app/views/items/_item_error.html.haml
+++ b/app/views/items/_item_error.html.haml
@@ -13,6 +13,7 @@
             画像を選択してください
           -elsif content == :price
             300以上9999999以下で入力してください
-          -elsif content == :size && params[:category_id].nil?
+          -elsif content == :size
+            サイズを選択してください
           -else
             選択してください

--- a/db/migrate/20190901150601_create_items.rb
+++ b/db/migrate/20190901150601_create_items.rb
@@ -4,14 +4,14 @@ class CreateItems < ActiveRecord::Migration[5.0]
       t.string      :name            ,null:false
       t.text        :detail          ,null:false
       t.integer     :price           ,null:false
-      t.string      :size            ,null:false
+      t.string      :size            
       t.string      :brand
       t.string      :condition       ,null:false
       t.string      :shipping_fee    ,null:false
       t.string      :shipping_method ,null:false
       t.string      :ship_out_area   ,null:false
       t.string      :ship_out_date   ,null:false
-      t.string      :category_id     ,null:false
+      t.integer     :category_id     ,null:false
       t.references  :user            ,foreign_key: true
       t.references  :status          ,foreign_key: true
       t.timestamps                   

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,15 +61,15 @@ ActiveRecord::Schema.define(version: 20191010160019) do
     t.string   "name",                          null: false
     t.text     "detail",          limit: 65535, null: false
     t.integer  "price",                         null: false
-    t.string   "size",                          null: false
+    t.string   "size"
     t.string   "brand"
     t.string   "condition",                     null: false
     t.string   "shipping_fee",                  null: false
     t.string   "shipping_method",               null: false
     t.string   "ship_out_area",                 null: false
     t.string   "ship_out_date",                 null: false
-    t.string   "category_id",                   null: false
-    t.integer  "user_id",                       null: false
+    t.integer  "category_id",                   null: false
+    t.integer  "user_id"
     t.integer  "status_id"
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false


### PR DESCRIPTION
【WIP】サイズのバリデーション修正と値段の小数点切り捨て機能の追加

# WHAT
今まではサイズの項目が不要なカテゴリーの場合なのに登録をしようとするとサイズのバリデーションに引っかかってしまっていたが、今回サイズの項目が必要ないカテゴリーの場合はバリデーションに引っかからないように修正した
商品の手数料・利益の項目で今までは小数点が汚く出ていたが、本物と同じように小数点は切り捨てるようにした

# WHY
サービスの向上のため